### PR TITLE
Replace p5.easycam link

### DIFF
--- a/src/libraries.json
+++ b/src/libraries.json
@@ -123,7 +123,7 @@
       }
     ],
     "desc": "Simple 3D camera control with inertial pan, zoom, and rotate. Major contributions by Thomas Diewald.",
-    "install": "https://github.com/freshfork/p5.EasyCam/blob/master/p5.easycam.min.js"
+    "install": "https://raw.githubusercontent.com/freshfork/p5.EasyCam/master/p5.easycam.min.js"
   },
   {
     "name": "p5.experience",


### PR DESCRIPTION
Replaced link:
https://github.com/freshfork/p5.EasyCam/blob/master/p5.easycam.min.js
with:
https://raw.githubusercontent.com/freshfork/p5.EasyCam/master/p5.easycam.min.js