### PR TITLE
Replace Live Server with Live Preview due to the former being abandoned

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ I made this extension for my students in particular, but I hope it's helpful for
 
 1. Open the Command Palette (with `command-shift-p` on Mac, or `ctrl-shift-p` on Windows) and then start typing and select `Create p5.js Project`. 
 2. Select a new empty folder to put your project in.
-3. (optional) click the "Go Live" button in the bottom status bar to open your sketch in a browser
+3. (optional) From the Command Palette use `Live Preview: Start Server` to run your project
 4. Abolish cops.
 
 ### To install p5 libraries:

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     ]
   },
   "extensionPack": [
-    "ritwickdey.liveserver"
+    "ms-vscode.live-server"
   ],
   "scripts": {
     "vscode:prepublish": "yarn run compile",


### PR DESCRIPTION
Live Server has issues such as "Use Browser Preview" no longer working, due to Browser Preview being deprecated in favor of Live Preview. Also, last release was in 17.04.19. It seems to have been a great extension in the past, but times move on and maintainers sometimes move on.

This PR attempts to replace Live Server with a suitable substitute, and also updates the documentation.

Note: I don't have any experience with vscode extensions, so I might have missed important things! If so, please tell me so I can investigate :)